### PR TITLE
Fix 403 by sending user agent

### DIFF
--- a/.github/workflows/rss-generator.yml
+++ b/.github/workflows/rss-generator.yml
@@ -12,63 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Python deps
-        run: python -m pip install --upgrade requests beautifulsoup4 lxml
-
       - name: Build RSS from Shigahochi
         run: |
-          python <<'PY'
-          import requests, datetime, email.utils, pathlib, html
-          from bs4 import BeautifulSoup
-
-          BASE_URL = "http://www.shigahochi.co.jp/"
-          TOP_URL = BASE_URL
-          now = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=9)))
-          last_build = email.utils.format_datetime(now)
-
-          # 取得
-          try:
-              r = requests.get(TOP_URL, timeout=20)
-              r.encoding = 'shift_jis'
-              soup = BeautifulSoup(r.text, "lxml")
-          except requests.RequestException as e:
-              print(f"ERROR: failed to fetch {TOP_URL}: {e}")
-              exit(0)
-          except Exception as e:
-              print(f"ERROR: failed to parse HTML: {e}")
-              exit(0)
-
-          # 記事リンクを抽出
-          items = []
-          for a in soup.select("p.sp-caption-txt1 a"):
-              title = a.get_text(strip=True)
-              link = a["href"]
-              if not link.startswith("http"):
-                  link = BASE_URL + link.lstrip("./")
-              pub = email.utils.format_datetime(now)
-              items.append(
-                  f"<item><title>{html.escape(title)}</title><link>{link}</link><guid>{link}</guid><pubDate>{pub}</pubDate></item>"
-              )
-
-          if not items:
-              print("No items scraped. rss.xml will not be updated.")
-              exit(0)
-
-          # RSS本文
-          rss = (
-              '<?xml version="1.0" encoding="UTF-8"?>\n'
-              '<rss version="2.0">\n<channel>\n'
-              '<title>滋賀報知新聞 新着記事</title>\n'
-              f'<link>{TOP_URL}</link>\n'
-              '<description>滋賀報知新聞トップページの新着記事をRSS配信</description>\n'
-              f'<lastBuildDate>{last_build}</lastBuildDate>\n'
-              + "\n".join(items) +
-              '\n</channel>\n</rss>'
-          )
-
-          pathlib.Path("rss.xml").write_text(rss, encoding="utf-8")
-          print("[DEBUG] rss.xml written")
-          PY
+          python rss_generator.py
 
       - name: Commit & push if changed
         run: |

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Shigahochi RSS
+
+This repository builds an RSS feed for the [Shigahochi Newspaper](http://www.shigahochi.co.jp/).
+A GitHub Actions workflow scrapes article links from the site's front page and commits
+`rss.xml` back into this repository. You can subscribe to the RSS file with any reader
+(such as Feedly) to receive updates automatically.
+
+## Workflow Overview
+
+The workflow `.github/workflows/rss-generator.yml` runs daily and can also be triggered
+manually. It executes `rss_generator.py` to fetch the latest articles and commits the
+resulting `rss.xml` if there are changes.
+
+The script relies only on Python's standard library, so you can run it locally
+with `python rss_generator.py` without installing extra packages.
+The fetch request now includes a simple `User-Agent` header to avoid being
+rejected by the server. If you still encounter HTTP 403 errors, your network or
+the site may be blocking access.
+
+## Using the Feed
+
+1. Navigate to the repository's `rss.xml` file.
+2. Copy the raw file URL (e.g., `https://raw.githubusercontent.com/<user>/<repo>/main/rss.xml`).
+3. Add that URL to your RSS reader such as Feedly.
+
+The feed will update automatically when the workflow runs.

--- a/rss_generator.py
+++ b/rss_generator.py
@@ -1,0 +1,95 @@
+import urllib.request
+import datetime
+import email.utils
+import pathlib
+import html
+from html.parser import HTMLParser
+
+BASE_URL = "http://www.shigahochi.co.jp/"
+TOP_URL = BASE_URL
+
+
+def build_rss():
+    now = datetime.datetime.now(
+        datetime.timezone(datetime.timedelta(hours=9))
+    )
+    last_build = email.utils.format_datetime(now)
+
+    try:
+        req = urllib.request.Request(
+            TOP_URL,
+            headers={"User-Agent": "Mozilla/5.0"}
+        )
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            html_data = resp.read().decode("shift_jis", errors="ignore")
+    except Exception as e:
+        print(f"ERROR: failed to fetch {TOP_URL}: {e}")
+        return False
+
+    class Parser(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.in_p = False
+            self.in_a = False
+            self.curr_link = ""
+            self.curr_title = ""
+            self.items = []
+
+        def handle_starttag(self, tag, attrs):
+            attrs = dict(attrs)
+            if tag == "p" and attrs.get("class") == "sp-caption-txt1":
+                self.in_p = True
+            elif tag == "a" and self.in_p:
+                self.in_a = True
+                self.curr_link = attrs.get("href", "")
+
+        def handle_data(self, data):
+            if self.in_a:
+                self.curr_title += data
+
+        def handle_endtag(self, tag):
+            if tag == "a" and self.in_a:
+                self.in_a = False
+            elif tag == "p" and self.in_p:
+                if self.curr_title and self.curr_link:
+                    self.items.append((self.curr_title.strip(), self.curr_link))
+                self.in_p = False
+                self.curr_title = ""
+                self.curr_link = ""
+
+    parser = Parser()
+    parser.feed(html_data)
+
+    items = []
+    for title, link in parser.items:
+        if not link.startswith("http"):
+            link = BASE_URL + link.lstrip("./")
+        pub = email.utils.format_datetime(now)
+        items.append(
+            f"<item><title>{html.escape(title)}</title>"
+            f"<link>{link}</link><guid>{link}</guid>"
+            f"<pubDate>{pub}</pubDate></item>"
+        )
+
+    if not items:
+        print("No items scraped. rss.xml will not be updated.")
+        return False
+
+    rss = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<rss version="2.0">\n<channel>\n'
+        '<title>滋賀報知新聞 新着記事</title>\n'
+        f'<link>{TOP_URL}</link>\n'
+        '<description>滋賀報知新聞トップページの新着記事をRSS配信</description>\n'
+        f'<lastBuildDate>{last_build}</lastBuildDate>\n'
+        + "\n".join(items) +
+        '\n</channel>\n</rss>'
+    )
+
+    pathlib.Path("rss.xml").write_text(rss, encoding="utf-8")
+    print("[DEBUG] rss.xml written")
+    return True
+
+
+if __name__ == "__main__":
+    build_rss()


### PR DESCRIPTION
## Summary
- document User-Agent usage in README
- send a basic User-Agent header when fetching the site

## Testing
- `python rss_generator.py` *(fails: HTTP Error 403 due to blocked network)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_687f3fa991988333b59f730efc1a5eae